### PR TITLE
Fix: TestRail configuration mapping

### DIFF
--- a/src/service/testrail.py
+++ b/src/service/testrail.py
@@ -18,7 +18,7 @@ class TestrailService:
 
         self.logger = logger
 
-        if config.get('testrail_db_host'):
+        if config.get('testrail.db.host'):
             self.db_repository = TestrailDbRepository(host=config.get('testrail.db.host'),
                              database=config.get('testrail.db.database'),
                              user=config.get('testrail.db.user'),


### PR DESCRIPTION
## Description
The current implementation uses underscores, not reading the TestRail configuration file properly
The current implementation assumes that `TestrailApiRepository` will be used regardless of the DB configuration.

## Solution
The new implementation replaces underscores with dots, access to `testrail.db.host`
```
"testrail": {
        "connection": "db",
        "db": {
            "host": "10.10.10.10",
            "database": "testrail"
            "user": "xxxxx",
            "password": "xxxxxx"
        }
}
```

The new implementation adds checks based on the configuration mapping to either use `TestrailApiRepository` or `TestrailDbRepository` accordingly.