### PR TITLE
SCIM Host Configuration

### DIFF
--- a/docs/testrail.md
+++ b/docs/testrail.md
@@ -31,6 +31,7 @@ Create a new config file from the example or use template:
     "qase": {
         "api_token": "<QASE_API_TOKEN>",
         "scim_token": "<QASE_SCIM_API_TOKEN>",
+        "scim_host": "<QASE_SCIM_HOST|Default:app.qase.io>",
         "host": "<QASE_API_HOST|Default:qase.io>",
         "ssl": true,
         "enterprise": false

--- a/src/service/qase_scim.py
+++ b/src/service/qase_scim.py
@@ -12,7 +12,7 @@ class QaseScimService:
         self.logger = logger
 
         self.client = QaseScimClient(
-            base_url=self.config.get('qase.host'), 
+            base_url=self.config.get('qase.scim_host'),
             token=self.config.get('qase.scim_token'), 
             ssl=bool(self.config.get('qase.ssl'))
         )


### PR DESCRIPTION
## Context

We have noticed that the script returns some errors when using SCIM and connecting to the host.

## Solution

Add a dedicated parameter in the configuration to define the SCIM host. By default, it is `app.qase.io`